### PR TITLE
feat: Facts Page

### DIFF
--- a/app/components/FactsPageContent.tsx
+++ b/app/components/FactsPageContent.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { Earthquakes } from '@/types';
+import { earthquakesAtom } from '@/store';
+import useSyncAtom from '@/store/useSyncAtom';
+import StandardQuakeCard from './StandardQuakeCard';
+
+type FactsPageContent = {
+  earthquakes: Earthquakes;
+  topMagnitudeEvents: Earthquakes;
+  totalCount: number;
+};
+
+const FactsPageContent = ({
+  earthquakes,
+
+  topMagnitudeEvents,
+  totalCount,
+}: FactsPageContent) => {
+  useSyncAtom(earthquakesAtom, earthquakes);
+
+  return (
+    <main className="flex flex-col gap-4 bg-black h-screen text-white">
+      <p>Number of quakes today: {totalCount}</p>
+      <div>
+        <p>Highest Magnitude Quakes Today</p>
+        <div className="flex gap-2">
+          {topMagnitudeEvents.map((event) => {
+            return (
+              <StandardQuakeCard
+                place={event.properties?.place}
+                mag={event.properties?.mag}
+                time={event.properties?.time}
+                url={event.properties?.url}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default FactsPageContent;

--- a/app/components/NavHeader.tsx
+++ b/app/components/NavHeader.tsx
@@ -8,7 +8,7 @@ const NavHeader = () => {
       <Link className="text-white" href="/">
         Earthquake Tracker
       </Link>
-      <Link className="text-white" href="/todays-stats">
+      <Link className="text-white" href="/facts">
         Daily Breakdown
       </Link>
     </div>

--- a/app/components/QuakeCard.tsx
+++ b/app/components/QuakeCard.tsx
@@ -91,15 +91,7 @@ const QuakeCard = ({ place, code, coords, mag, time, url }: QuakeCardProps) => {
 //TODO: add sorting, mass delete
 const QuakeCards = () => {
   const earthquakes = useAtomValue(selectedEarthquakesAtom);
-  const setSelectedEarthquakes = useSetAtom(selectedEarthquakesAtom);
 
-  const removeQuake = (quake: any) => {
-    setSelectedEarthquakes((prevFeatures) =>
-      prevFeatures.filter(
-        (feature: any) => feature.properties.code !== quake.properties.code
-      )
-    );
-  };
   // return a map tool icon when null, or closed
   if (!earthquakes.length) return null;
   return (

--- a/app/components/StandardQuakeCard.tsx
+++ b/app/components/StandardQuakeCard.tsx
@@ -1,0 +1,53 @@
+'use client';
+import Link from 'next/link';
+import classNames from 'classnames';
+
+type QuakeCardProps = {
+  place: string;
+  mag: string;
+  time: string;
+  url: string;
+};
+
+// have a need for a non-interactive "quake card" - but I don't feel like adding a bunch of conditionals to the QuakeCard
+const StandardQuakeCard = ({ place, mag, time, url }: QuakeCardProps) => {
+  const name = place;
+  const magnitude = Number(parseFloat(mag).toFixed(1));
+
+  /** color the magnitude section of the card based on event severity */
+  const magClass = classNames({
+    'bg-green-500': magnitude < 2,
+    'bg-yellow-500': magnitude >= 2 && magnitude < 4,
+    'bg-orange-500': magnitude >= 4 && magnitude < 6,
+    'bg-red-500': magnitude >= 6,
+  });
+
+  return (
+    <div className="relative bg-purple-heart-100 rounded-lg shadow-lg cursor-pointer p-3 text-color-purple-heart-950">
+      <div
+        className={classNames('p-[2px] px-[6px] w-min rounded-lg', magClass)}
+      >
+        <p
+          style={{
+            fontWeight: 'bold',
+            color: 'white',
+          }}
+        >
+          {parseFloat(mag).toFixed(1)}
+        </p>
+      </div>
+
+      {/** divider */}
+      <div>
+        <p>{name}</p>
+        <p>{new Date(time).toLocaleString()}</p>
+
+        <Link href={url} target="_blank">
+          Details
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default StandardQuakeCard;

--- a/app/facts/page.tsx
+++ b/app/facts/page.tsx
@@ -1,0 +1,18 @@
+import { fetchAndProcessEarthquakes } from '@/utils/fetchEarthquakes';
+import FactsPageContent from '../components/FactsPageContent';
+export default async function FactsPage() {
+  // we need to also fetch the earthquakes here
+  // if the user comes directly to the facts page, we won't init/see the map
+  // we'll also do some pre-processing for the stuff we show on the facts page
+  const processedEarthQuakesData = await fetchAndProcessEarthquakes();
+
+  return (
+    <div className="relative">
+      <FactsPageContent
+        earthquakes={processedEarthQuakesData.earthquakes}
+        totalCount={processedEarthQuakesData.totalCount}
+        topMagnitudeEvents={processedEarthQuakesData.topMagnitudeEvents}
+      />
+    </div>
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,5 @@
+import { Feature, Point } from 'geojson';
+
+export type EarthquakeFeature = Feature<Point>;
+
+export type Earthquakes = EarthquakeFeature[];

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -27,16 +27,6 @@ export const fetchAndProcessEarthquakes =
     );
 
     const earthquakes = res.data.features;
-    // reduce the earthquakes array to one - the one with the highest magnitude
-    // on second thought - let's get the top 5 events
-    // const highestMagnitude = earthquakes.reduce(
-    //   (acc: EarthquakeFeature, curr: EarthquakeFeature) => {
-    //     if (acc.properties?.mag > curr.properties?.mag) {
-    //       return acc;
-    //     }
-    //     return curr;
-    //   }
-    // );
     const topMagnitudeEvents = earthquakes
       // sort array based on magnitude, in descending order
       .sort(
@@ -45,7 +35,6 @@ export const fetchAndProcessEarthquakes =
       )
       // take the top 5
       .slice(0, 5);
-
     const totalCount = earthquakes.length;
 
     return { earthquakes, topMagnitudeEvents, totalCount };

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -1,9 +1,52 @@
 import axios from 'axios';
+import { Earthquakes, EarthquakeFeature } from '@/types';
 
-export const fetchEarthquakes = async () => {
+export const fetchEarthquakes = async (): Promise<Earthquakes> => {
   const res = await axios.get(
     'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
   );
 
   return res.data.features;
 };
+
+// Right now we don't have this wired up to a database
+// that's okay, we'll just do some pre-processing for now
+// while this won't be the most efficient, it'll work for now
+// in the future we can look into adding a database
+// we'd then get some interesting tools to work with the geojson data
+type ProcessedEarthquakes = {
+  earthquakes: Earthquakes;
+  topMagnitudeEvents: Earthquakes;
+  totalCount: number;
+};
+
+export const fetchAndProcessEarthquakes =
+  async (): Promise<ProcessedEarthquakes> => {
+    const res = await axios.get(
+      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
+    );
+
+    const earthquakes = res.data.features;
+    // reduce the earthquakes array to one - the one with the highest magnitude
+    // on second thought - let's get the top 5 events
+    // const highestMagnitude = earthquakes.reduce(
+    //   (acc: EarthquakeFeature, curr: EarthquakeFeature) => {
+    //     if (acc.properties?.mag > curr.properties?.mag) {
+    //       return acc;
+    //     }
+    //     return curr;
+    //   }
+    // );
+    const topMagnitudeEvents = earthquakes
+      // sort array based on magnitude, in descending order
+      .sort(
+        (a: EarthquakeFeature, b: EarthquakeFeature) =>
+          b.properties?.mag - a.properties?.mag
+      )
+      // take the top 5
+      .slice(0, 5);
+
+    const totalCount = earthquakes.length;
+
+    return { earthquakes, topMagnitudeEvents, totalCount };
+  };


### PR DESCRIPTION
- Adds types to make working with the earthquakes data easier 
- Adds `FactsPageContent` - should eventually be broken up into components, if parts seem reusable 
- Adds `fetchAndProcessEarthquakes` - this function does some good ol' JS on the data we get back from the usgs API. It would be better to build a cool database with supabase or something, but right now I'm focused on getting an MVP up and using JS will do 
- Gets earthquake data on the server in facts/page 