### PR TITLE
feat: add more data

### DIFF
--- a/app/components/FactsPageContent.tsx
+++ b/app/components/FactsPageContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useAtomValue } from 'jotai';
 import { Earthquakes } from '@/types';
-import { earthquakesAtom } from '@/store';
+import { earthquakesAtom, weeklyTopMagnitudeEventsAtom } from '@/store';
 import useSyncAtom from '@/store/useSyncAtom';
 import StandardQuakeCard from './StandardQuakeCard';
 import { FaEarthAsia } from 'react-icons/fa6';
@@ -11,40 +11,81 @@ type FactsPageContent = {
   earthquakes: Earthquakes;
   topMagnitudeEvents: Earthquakes;
   totalCount: number;
+  weeklyTopMagnitudeEvents: Earthquakes;
 };
 
+//TODO: break this up into components
 const FactsPageContent = ({
   earthquakes,
-
   topMagnitudeEvents,
   totalCount,
+  weeklyTopMagnitudeEvents,
 }: FactsPageContent) => {
   useSyncAtom(earthquakesAtom, earthquakes);
+  useSyncAtom(weeklyTopMagnitudeEventsAtom, weeklyTopMagnitudeEvents);
   const currentDate = useAtomValue(currentDateStringAtom);
+  const weekEvents = useAtomValue(weeklyTopMagnitudeEventsAtom);
 
   return (
-    <main className="flex flex-col gap-4 bg-black-900 h-screen text-white p-10 ">
-      <h1 className="text-5xl">Overview - {currentDate}</h1>
-      <div className="relative flex justify-center items-center gap-2 p-16 bg-black-100 text-purple-heart-900 w-[300px]  shadow-lg rounded-lg">
-        <p className="absolute text-sm text-black-700 top-3 left-4">
-          Earthquakes Today
-        </p>
-        <FaEarthAsia size="40px" />
-        <p className="text-4xl">{totalCount}</p>
-      </div>
-      <div>
-        <h2 className="pb-4 text-4xl">Notable Events</h2>
-        <div className="flex flex-wrap gap-4">
-          {topMagnitudeEvents.map((event) => {
-            return (
-              <StandardQuakeCard
-                place={event.properties?.place}
-                mag={event.properties?.mag}
-                time={event.properties?.time}
-                url={event.properties?.url}
-              />
-            );
-          })}
+    <main className="flex flex-col gap-4 bg-black-950 h-screen text-white px-20 py-10">
+      <div className="bg-purple-heart-950 p-12 rounded-xl animate-slideUp">
+        <span
+          className="flex"
+          style={{
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <h1 className="text-6xl font-medium">Overview</h1>
+          {/** Calendar Component */}
+          <div className="flex flex-col items-center p-4 bg-gray-100 rounded-lg shadow-inner">
+            <p className="text-sm font-medium text-gray-500">Today</p>
+            <p className="text-xl font-bold text-purple-heart-900">
+              {currentDate}
+            </p>
+          </div>
+        </span>
+        <div className="flex py-6 justify-center">
+          <div className="relative flex justify-center items-center gap-6 p-12 bg-black-100 text-purple-heart-900 w-[300px]  shadow-lg rounded-lg">
+            <p className="absolute text-sm font-medium text-gray-500 top-3 left-4">
+              Total Earthquakes
+            </p>
+            <FaEarthAsia size="80px" />
+            <p className="text-5xl font-medium">{totalCount}</p>
+          </div>
+        </div>
+        <div>
+          {/** EventSection card - take events and title */}
+          <h2 className="text-5xl">Notable Events</h2>
+          <h3 className="py-8 text-4xl">Today</h3>
+          <div className="flex justify-center flex-wrap gap-8 py-2">
+            {topMagnitudeEvents.map((event) => {
+              return (
+                <StandardQuakeCard
+                  key={event.properties?.code}
+                  place={event.properties?.place}
+                  mag={event.properties?.mag}
+                  time={event.properties?.time}
+                  url={event.properties?.url}
+                />
+              );
+            })}
+          </div>
+
+          <h3 className="py-8 text-4xl">This Week</h3>
+          <div className="flex  justify-center flex-wrap gap-8 py-2">
+            {weekEvents.map((event) => {
+              return (
+                <StandardQuakeCard
+                  key={event.properties?.code}
+                  place={event.properties?.place}
+                  mag={event.properties?.mag}
+                  time={event.properties?.time}
+                  url={event.properties?.url}
+                />
+              );
+            })}
+          </div>
         </div>
       </div>
     </main>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -21,7 +21,8 @@ type PopupInfo = {
   x: number;
   y: number;
 };
-
+// TODO: breakout the layers
+// TODO: Add a layer for the weeks high magnitude events
 const Map = ({ earthquakes }: MapProps) => {
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapRef | null>(null);

--- a/app/components/NavHeader.tsx
+++ b/app/components/NavHeader.tsx
@@ -4,8 +4,8 @@ import { FaEarthAsia } from 'react-icons/fa6';
 
 const NavHeader = () => {
   return (
-    <div className="flex items-center h-[60px] bg-purple-heart-950 gap-4 px-4 py-4 text-white text-lg">
-      <FaEarthAsia size="25px" color="white" />
+    <div className="flex items-center h-[60px] bg-purple-heart-950 gap-4 px-4 py-4 text-white text-lg font-medium">
+      <FaEarthAsia size="30px" color="white" />
       <Link href="/">Earthquake Tracker</Link>
       <Link href="/facts">Daily Breakdown</Link>
     </div>

--- a/app/facts/page.tsx
+++ b/app/facts/page.tsx
@@ -1,15 +1,12 @@
 import {
   fetchAndProcessEarthquakes,
-  fetchLastWeekHighMagnitudeEarthquakes,
+  fetchLastWeekTopMagnitudeEarthquakes,
 } from '@/utils/fetchEarthquakes';
 import FactsPageContent from '../components/FactsPageContent';
+
 export default async function FactsPage() {
-  // we need to also fetch the earthquakes here
-  // if the user comes directly to the facts page, we won't init/see the map
-  // we'll also do some pre-processing for the stuff we show on the facts page
   const processedEarthQuakesData = await fetchAndProcessEarthquakes();
-  const weeklyTopMagnitudeEvents =
-    await fetchLastWeekHighMagnitudeEarthquakes();
+  const weeklyTopMagnitudeEvents = await fetchLastWeekTopMagnitudeEarthquakes();
 
   return (
     <div className="relative">

--- a/app/facts/page.tsx
+++ b/app/facts/page.tsx
@@ -1,14 +1,20 @@
-import { fetchAndProcessEarthquakes } from '@/utils/fetchEarthquakes';
+import {
+  fetchAndProcessEarthquakes,
+  fetchLastWeekHighMagnitudeEarthquakes,
+} from '@/utils/fetchEarthquakes';
 import FactsPageContent from '../components/FactsPageContent';
 export default async function FactsPage() {
   // we need to also fetch the earthquakes here
   // if the user comes directly to the facts page, we won't init/see the map
   // we'll also do some pre-processing for the stuff we show on the facts page
   const processedEarthQuakesData = await fetchAndProcessEarthquakes();
+  const weeklyTopMagnitudeEvents =
+    await fetchLastWeekHighMagnitudeEarthquakes();
 
   return (
     <div className="relative">
       <FactsPageContent
+        weeklyTopMagnitudeEvents={weeklyTopMagnitudeEvents}
         earthquakes={processedEarthQuakesData.earthquakes}
         totalCount={processedEarthQuakesData.totalCount}
         topMagnitudeEvents={processedEarthQuakesData.topMagnitudeEvents}

--- a/store/index.ts
+++ b/store/index.ts
@@ -4,6 +4,8 @@ import { MapRef } from 'react-map-gl';
 
 export const earthquakesAtom = atom<Feature<Point>[]>([]);
 
+export const weeklyTopMagnitudeEventsAtom = atom<Feature<Point>[]>([]);
+
 export const selectedEarthquakesAtom = atom<Feature<Point>[]>([]);
 
 export const mapRefAtom = atom<MapRef | null>(null);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'tailwindcss';
-
+// TODO: add text shadow utility
 const config: Config = {
   content: [
     './pages/**/*.{js,ts,jsx,tsx,mdx}',
@@ -35,6 +35,15 @@ const config: Config = {
           '900': '#333346',
           '950': '#020203',
         },
+      },
+      keyframes: {
+        slideUp: {
+          '0%': { transform: 'translateY(100%)', opacity: '0' },
+          '100%': { transform: 'translateY(0)', opacity: '1' },
+        },
+      },
+      animation: {
+        slideUp: 'slideUp 0.3s ease-out forwards',
       },
     },
   },

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -11,7 +11,7 @@ export const fetchEarthquakes = async (): Promise<Earthquakes> => {
 };
 
 /** Fetch all the highest magnitude earthquakes from the last week */
-export const fetchLastWeekHighMagnitudeEarthquakes =
+export const fetchLastWeekTopMagnitudeEarthquakes =
   async (): Promise<Earthquakes> => {
     const res = await axios.get(
       'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_week.geojson'
@@ -19,7 +19,7 @@ export const fetchLastWeekHighMagnitudeEarthquakes =
 
     const earthquakes = res.data.features;
     // sort and return 4, like the other function
-    const top4highestMagnitude = earthquakes
+    const weeklyTopMagnitudeEvents = earthquakes
       // sort array based on magnitude, in descending order
       .sort(
         (a: EarthquakeFeature, b: EarthquakeFeature) =>
@@ -28,7 +28,7 @@ export const fetchLastWeekHighMagnitudeEarthquakes =
       // take the top 5
       .slice(0, 4);
 
-    return top4highestMagnitude;
+    return weeklyTopMagnitudeEvents;
   };
 
 // Right now we don't have this wired up to a database

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { Earthquakes, EarthquakeFeature } from '@/types';
 
+/** Fetch all the earthquake events from today so far */
 export const fetchEarthquakes = async (): Promise<Earthquakes> => {
   const res = await axios.get(
     'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
@@ -8,6 +9,27 @@ export const fetchEarthquakes = async (): Promise<Earthquakes> => {
 
   return res.data.features;
 };
+
+/** Fetch all the highest magnitude earthquakes from the last week */
+export const fetchLastWeekHighMagnitudeEarthquakes =
+  async (): Promise<Earthquakes> => {
+    const res = await axios.get(
+      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_week.geojson'
+    );
+
+    const earthquakes = res.data.features;
+    // sort and return 4, like the other function
+    const top4highestMagnitude = earthquakes
+      // sort array based on magnitude, in descending order
+      .sort(
+        (a: EarthquakeFeature, b: EarthquakeFeature) =>
+          b.properties?.mag - a.properties?.mag
+      )
+      // take the top 5
+      .slice(0, 4);
+
+    return top4highestMagnitude;
+  };
 
 // Right now we don't have this wired up to a database
 // that's okay, we'll just do some pre-processing for now
@@ -20,13 +42,13 @@ type ProcessedEarthquakes = {
   totalCount: number;
 };
 
+/** Fetch earthquakes and process:
+ * Get 4 highest magnitude events
+ * Return total count of events
+ */
 export const fetchAndProcessEarthquakes =
   async (): Promise<ProcessedEarthquakes> => {
-    const res = await axios.get(
-      'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
-    );
-
-    const earthquakes = res.data.features;
+    const earthquakes = await fetchEarthquakes();
     const topMagnitudeEvents = earthquakes
       // sort array based on magnitude, in descending order
       .sort(
@@ -34,10 +56,8 @@ export const fetchAndProcessEarthquakes =
           b.properties?.mag - a.properties?.mag
       )
       // take the top 5
-      .slice(0, 5);
+      .slice(0, 4);
     const totalCount = earthquakes.length;
 
     return { earthquakes, topMagnitudeEvents, totalCount };
   };
-
-// what other endpoints are there? Can we get historical data? Like the total count for x-amount of time?


### PR DESCRIPTION
- Adds API call to `fetchEarthquakes` module
- Adds a `slideUp` animation to the tailwind config 
- Adds more structure to the facts page (again), and adds the section for this week's notable mag events:

<img width="1274" alt="image" src="https://github.com/ash-bergs/earthquake-tracker/assets/65979049/86b6ff2f-d604-4286-8eac-d9e48bad83ac">

