### PR TITLE
feat: events graph base 

### DIFF
--- a/app/components/FactPageContent/CircularScale.tsx
+++ b/app/components/FactPageContent/CircularScale.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+const HalfCircularScale = ({
+  value,
+  maxValue,
+}: {
+  value: number;
+  maxValue: number;
+}) => {
+  const radius = 50;
+  const circumference = Math.PI * radius;
+  // amount of half circle to be filled based on passed values
+  const percentage = value / maxValue;
+  // stroke offset to determine the length of the colored arc
+  const strokeDashoffset = circumference * (1 - percentage);
+
+  return (
+    <svg className="w-auto h-auto transform" viewBox="0 0 100 50">
+      <defs>
+        <linearGradient id="gradient" gradientTransform="rotate(0)">
+          <stop offset="0%" stopColor="#3b82f6" /> {/* Blue */}
+          <stop offset="25%" stopColor="#10b981" /> {/* Green */}
+          <stop offset="50%" stopColor="#fbbf24" /> {/* Yellow */}
+          <stop offset="75%" stopColor="#f59e0b" /> {/* Orange */}
+          <stop offset="100%" stopColor="#ef4444" /> {/* Red */}
+        </linearGradient>
+      </defs>
+      <path
+        d="
+          M 10,50
+          A 40,40 0 0 1 90,50
+        "
+        fill="none"
+        stroke="#d1d5db"
+        strokeWidth="10"
+      />
+      <path
+        d="
+          M 10,50
+          A 40,40 0 0 1 90,50
+        "
+        fill="none"
+        stroke="url(#gradient)"
+        strokeWidth="10"
+        strokeDasharray={circumference}
+        strokeDashoffset={strokeDashoffset}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default HalfCircularScale;

--- a/app/components/FactPageContent/StatsSection.tsx
+++ b/app/components/FactPageContent/StatsSection.tsx
@@ -4,6 +4,7 @@ import { Earthquakes } from '@/types';
 import StandardQuakeCard from '../StandardQuakeCard';
 import { FaEarthAsia } from 'react-icons/fa6';
 import { currentDateStringAtom, currentWeekRangeStringAtom } from '@/store';
+import CircularScale from './CircularScale';
 
 type StatsSectionProps = {
   totalCount: number;
@@ -22,6 +23,7 @@ const StatsSection = ({
   const headerText = isWeekly ? 'This week' : 'Today'; // will need to use the date to determine if this is TODAY or THIS WEEK
   const calendarText = isWeekly ? 'Week' : 'Today';
   const calendarDate = isWeekly ? weekRange : currentDate;
+  const maxValue = isWeekly ? 5000 : 600;
 
   return (
     <div className="flex flex-col gap-20 text-white px-20 py-10">
@@ -46,7 +48,7 @@ const StatsSection = ({
             <p className="absolute text-sm font-medium text-gray-500 top-3 left-4">
               Total Earthquakes
             </p>
-            <div className="bg-blue-500 w-[100%] h-[200px]" />
+            <CircularScale value={totalCount} maxValue={maxValue} />
             <div className="flex items-center gap-2">
               <FaEarthAsia size="60px" />
               <p className="text-5xl font-medium">{totalCount}</p>


### PR DESCRIPTION
- Adds an SVG scale to render a visual guage of the amount of events for today 

<img width="462" alt="image" src="https://github.com/user-attachments/assets/87229cb8-e41c-4828-8f02-896188fda990">

I liked this solution better than using a charting library (seems more lightweight) - though we will need one for the bar/plot/whatever graph I build in the other section 

This will need an 'info' icon and a tooltip for "How is this calculated?" and I need to do some research 