### PR TITLE
feat: WeeklyStats and DailyStats Sections 

### DIFF
--- a/app/components/Charts/WeeklyEarthquakeChart.tsx
+++ b/app/components/Charts/WeeklyEarthquakeChart.tsx
@@ -1,0 +1,87 @@
+import { ResponsiveBar } from '@nivo/bar';
+import { useAtomValue } from 'jotai';
+import { eventsByWeekdayAtom } from '@/store';
+
+const colorScale = [
+  '#bae6fd', // Light Blue
+  '#7dd3fc', // Medium Blue
+  '#38bdf8', // Darker Blue
+  '#ff6d82', // Light Peachy
+  '#fa506d', // Peachy
+];
+
+const getColorForCount = (count: number): string => {
+  if (count <= 50) return colorScale[0];
+  if (count > 50 && count <= 70) return colorScale[1];
+  if (count > 70 && count <= 100) return colorScale[2];
+  if (count > 100 && count <= 100) return colorScale[3];
+  return colorScale[4];
+};
+
+const WeeklyEarthquakeChart: React.FC = () => {
+  const data = useAtomValue(eventsByWeekdayAtom);
+
+  if (!data) return null;
+
+  // make a structure for the graph - [{day: string, count: number, color: string}]
+  const chartData = Object.entries(data)
+    .map(([day, count]) => ({
+      date: day,
+      count,
+      color: getColorForCount(count),
+    }))
+    .reverse(); // reverse to lead UP to today, as the week range displays
+
+  return (
+    <div style={{ width: '100%', height: '100%' }}>
+      <ResponsiveBar
+        data={chartData}
+        // keys determines the height of each bar
+        keys={['count']}
+        // x-axis
+        indexBy="date"
+        margin={{ top: 20, right: 60, bottom: 80, left: 60 }}
+        padding={0.5}
+        // colors can be a fn of a string array
+        colors={({ data }) => data.color}
+        // min and max for the y axis
+        minValue={0}
+        maxValue={100}
+        axisBottom={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 45,
+          legend: 'Date',
+          legendPosition: 'middle',
+          legendOffset: 70,
+        }}
+        axisLeft={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 0,
+          legend: 'Number of Events',
+          legendPosition: 'middle',
+          legendOffset: -40,
+        }}
+        tooltip={({ id, value, color }) => (
+          <div
+            style={{
+              padding: '12px',
+              color,
+              background: '#222222',
+            }}
+          >
+            <strong>
+              {id}: {value}
+            </strong>
+          </div>
+        )}
+        labelSkipWidth={12}
+        labelSkipHeight={12}
+        labelTextColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
+      />
+    </div>
+  );
+};
+
+export default WeeklyEarthquakeChart;

--- a/app/components/Charts/WeeklyEarthquakeChart.tsx
+++ b/app/components/Charts/WeeklyEarthquakeChart.tsx
@@ -1,6 +1,6 @@
 import { ResponsiveBar } from '@nivo/bar';
 import { useAtomValue } from 'jotai';
-import { eventsByWeekdayAtom } from '@/store';
+import { EventsDateAndCountAtom } from '@/store';
 
 const colorScale = [
   '#bae6fd', // Light Blue
@@ -19,7 +19,7 @@ const getColorForCount = (count: number): string => {
 };
 
 const WeeklyEarthquakeChart: React.FC = () => {
-  const data = useAtomValue(eventsByWeekdayAtom);
+  const data = useAtomValue(EventsDateAndCountAtom);
 
   if (!data) return null;
 

--- a/app/components/FactsPageContent.tsx
+++ b/app/components/FactsPageContent.tsx
@@ -1,37 +1,36 @@
 'use client';
 
-import { Earthquakes } from '@/types';
-import StatsSection from './StatsSection/StatsSection';
 import useSyncAtom from '@/store/useSyncAtom';
-import { allDailyEventsAtom, dailyEventsWithTimesAtom } from '@/store';
+import {
+  allDailyEventsAtom,
+  dailyEventsWithTimesAtom,
+  allWeeklyEventsAtom,
+  eventsByWeekdayAtom,
+} from '@/store';
+import { DailyStatsSection, WeeklyStatsSection } from './StatsSection';
 
+//TODO: TYPES
 type FactsPageContent = {
   allDailyEvents: any;
+  allWeeklyEvents: any;
   dailyEventsWithTimes: any;
-  topMagnitudeEvents: Earthquakes;
-  totalCount: number;
-  weeklyTotalCount: number;
-  weeklyTopMagnitudeEvents: Earthquakes;
+  eventsByDate: any;
 };
 
 const FactsPageContent = ({
   allDailyEvents,
   dailyEventsWithTimes,
-  topMagnitudeEvents,
-  totalCount,
-  weeklyTotalCount,
-  weeklyTopMagnitudeEvents,
+  allWeeklyEvents,
+  eventsByDate,
 }: FactsPageContent) => {
-  useSyncAtom(dailyEventsWithTimesAtom, dailyEventsWithTimes);
   useSyncAtom(allDailyEventsAtom, allDailyEvents);
+  useSyncAtom(dailyEventsWithTimesAtom, dailyEventsWithTimes);
+  useSyncAtom(allWeeklyEventsAtom, allWeeklyEvents);
+  useSyncAtom(eventsByWeekdayAtom, eventsByDate);
   return (
     <main className="h-[screen]">
-      <StatsSection topEvents={topMagnitudeEvents} totalCount={totalCount} />
-      <StatsSection
-        isWeekly
-        topEvents={weeklyTopMagnitudeEvents}
-        totalCount={weeklyTotalCount}
-      />
+      <DailyStatsSection />
+      <WeeklyStatsSection />
     </main>
   );
 };

--- a/app/components/FactsPageContent.tsx
+++ b/app/components/FactsPageContent.tsx
@@ -11,7 +11,6 @@ import { DailyStatsSection, WeeklyStatsSection } from './StatsSection';
 import { Earthquakes, EventsDateAndCount } from '@/types';
 import { EventTimeAndMagnitude } from '@/utils/fetchEarthquakes';
 
-//TODO: TYPES
 type FactsPageContent = {
   allDailyEvents: Earthquakes;
   allWeeklyEvents: Earthquakes;

--- a/app/components/FactsPageContent.tsx
+++ b/app/components/FactsPageContent.tsx
@@ -5,16 +5,18 @@ import {
   allDailyEventsAtom,
   dailyEventsWithTimesAtom,
   allWeeklyEventsAtom,
-  eventsByWeekdayAtom,
+  EventsDateAndCountAtom,
 } from '@/store';
 import { DailyStatsSection, WeeklyStatsSection } from './StatsSection';
+import { Earthquakes, EventsDateAndCount } from '@/types';
+import { EventTimeAndMagnitude } from '@/utils/fetchEarthquakes';
 
 //TODO: TYPES
 type FactsPageContent = {
-  allDailyEvents: any;
-  allWeeklyEvents: any;
-  dailyEventsWithTimes: any;
-  eventsByDate: any;
+  allDailyEvents: Earthquakes;
+  allWeeklyEvents: Earthquakes;
+  dailyEventsWithTimes: EventTimeAndMagnitude[];
+  eventsByDate: EventsDateAndCount;
 };
 
 const FactsPageContent = ({
@@ -26,7 +28,7 @@ const FactsPageContent = ({
   useSyncAtom(allDailyEventsAtom, allDailyEvents);
   useSyncAtom(dailyEventsWithTimesAtom, dailyEventsWithTimes);
   useSyncAtom(allWeeklyEventsAtom, allWeeklyEvents);
-  useSyncAtom(eventsByWeekdayAtom, eventsByDate);
+  useSyncAtom(EventsDateAndCountAtom, eventsByDate);
   return (
     <main className="h-[screen]">
       <DailyStatsSection />

--- a/app/components/StatsSection/DailyStatsSection.tsx
+++ b/app/components/StatsSection/DailyStatsSection.tsx
@@ -1,30 +1,24 @@
 import { useAtomValue } from 'jotai';
-import { Earthquakes } from '@/types';
-import { currentDateStringAtom, currentWeekRangeStringAtom } from '@/store';
+import {
+  currentDateStringAtom,
+  allDailyEventsAtom,
+  dailyTopEventsAtom,
+  dailyActiveLocationsAtom,
+} from '@/store';
 import BreakdownCalendar from './BreakdownCalendar';
 import MostActiveLocations from './MostActiveLocations';
 import StandardQuakeCard from '../StandardQuakeCard';
 import TotalEarthquakes from './TotalEarthquakes';
 import DailyEarthquakeChart from '../Charts/DailyEarthquakeChart';
 
-type StatsSectionProps = {
-  totalCount: number;
-  topEvents: Earthquakes;
-  isWeekly?: boolean; // might want to tweak this approach later, but for now we're just doing day/week
-};
-
-const StatsSection = ({
-  topEvents,
-  totalCount,
-  isWeekly,
-}: StatsSectionProps) => {
+const DailyStatsSection = () => {
   const currentDate = useAtomValue(currentDateStringAtom);
-  const weekRange = useAtomValue(currentWeekRangeStringAtom);
+  const dailyEvents = useAtomValue(allDailyEventsAtom);
+  const topEvents = useAtomValue(dailyTopEventsAtom);
+  const activeLocations = useAtomValue(dailyActiveLocationsAtom);
+  const totalCount = dailyEvents?.length;
 
-  const headerText = isWeekly ? 'This week' : 'Today';
-  const calendarText = isWeekly ? 'Week of' : 'Date';
-  const calendarDate = isWeekly ? weekRange : currentDate;
-  const maxValue = isWeekly ? 600 : 100;
+  if (!dailyEvents) return null; //TODO: return spinner
 
   return (
     <div className="flex flex-col gap-20 px-4 py-10 sm:px-10 md:px-10 lg:px-20 xl:px-40 2xl:px-80">
@@ -35,15 +29,11 @@ const StatsSection = ({
             className="border-[0.75px] border-gray-100 
             flex bg-white rounded-lg p-4
              "
-            //style={{ border: '1px solid red' }}
           >
-            <p className="text-4xl font-bold text-blue-800">{headerText}</p>
+            <p className="text-4xl font-bold text-blue-800">Today</p>
           </div>
-          <BreakdownCalendar
-            calendarDate={calendarDate}
-            calendarText={calendarText}
-          />
-          <TotalEarthquakes totalCount={totalCount} maxValue={maxValue} />
+          <BreakdownCalendar calendarDate={currentDate} calendarText="Date" />
+          <TotalEarthquakes totalCount={totalCount} maxValue={100} />
         </div>
 
         {/** Events Graph and Most Active area */}
@@ -51,13 +41,13 @@ const StatsSection = ({
         <div className="flex flex-col gap-4">
           <div className="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm sm:w-[100%] md:w-[325px] lg:w-[400px] xl:w-[100%] border-[0.75px] border-gray-100">
             <p className="text-lg font-semibold text-blue-800">
-              Events Throughout {isWeekly ? 'Week' : 'Day'}
+              Events Throughout Day
             </p>
             <div style={{ width: '100%', height: '325px' }}>
               <DailyEarthquakeChart />
             </div>
           </div>
-          <MostActiveLocations />
+          <MostActiveLocations locations={activeLocations} />
         </div>
 
         {/** Top 3 of the Day */}
@@ -66,17 +56,18 @@ const StatsSection = ({
             Notable Events
           </h2>
           <div className="flex flex-col justify-center flex-wrap gap-6 ">
-            {topEvents.map((event) => {
-              return (
-                <StandardQuakeCard
-                  key={event.properties?.code}
-                  place={event.properties?.place}
-                  mag={event.properties?.mag}
-                  time={event.properties?.time}
-                  url={event.properties?.url}
-                />
-              );
-            })}
+            {topEvents &&
+              topEvents.map((event) => {
+                return (
+                  <StandardQuakeCard
+                    key={event.properties?.code}
+                    place={event.properties?.place}
+                    mag={event.properties?.mag}
+                    time={event.properties?.time}
+                    url={event.properties?.url}
+                  />
+                );
+              })}
           </div>
         </div>
       </div>
@@ -84,4 +75,4 @@ const StatsSection = ({
   );
 };
 
-export default StatsSection;
+export default DailyStatsSection;

--- a/app/components/StatsSection/MostActiveLocations.tsx
+++ b/app/components/StatsSection/MostActiveLocations.tsx
@@ -1,11 +1,12 @@
 import { FaEarthAsia } from 'react-icons/fa6';
-import { useAtomValue } from 'jotai';
-import { dailyActiveLocationsAtom } from '@/store';
 
-const MostActiveLocations = () => {
-  const locations = useAtomValue(dailyActiveLocationsAtom);
+type MostActiveLocationsProps = {
+  locations: any; //TODO: TYPE - number key, string value
+};
 
+const MostActiveLocations = ({ locations }: MostActiveLocationsProps) => {
   if (!locations) return null;
+  // doing one right now, because I'm not sure how I want this UI to be
   const mostActiveLocation = locations[0];
 
   return (

--- a/app/components/StatsSection/TotalEarthquakes.tsx
+++ b/app/components/StatsSection/TotalEarthquakes.tsx
@@ -6,11 +6,13 @@ import Link from 'next/link';
 import ToolTip from '../ToolTip/ToolTip';
 
 type TotalEarthquakesProps = {
-  totalCount: number;
+  totalCount?: number;
   maxValue: number;
 };
 
 const TotalEarthquakes = ({ totalCount, maxValue }: TotalEarthquakesProps) => {
+  if (!totalCount) return null; //TODO: return spinner or "unknown state" component
+
   return (
     <div className="flex flex-col  p-4 bg-white text-blue-900 shadow-sm rounded-lg border-[0.75px] border-gray-100">
       <p className="text-lg font-semibold text-blue-800">Total Earthquakes</p>

--- a/app/components/StatsSection/WeeklyStatsSection.tsx
+++ b/app/components/StatsSection/WeeklyStatsSection.tsx
@@ -41,7 +41,7 @@ const WeeklyStatsSection = () => {
         <div className="flex flex-col gap-4">
           <div className="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm sm:w-[100%] md:w-[325px] lg:w-[400px] xl:w-[100%] border-[0.75px] border-gray-100">
             <p className="text-lg font-semibold text-blue-800">
-              Events Throughout Day
+              Events Throughout Week
             </p>
             <div style={{ width: '100%', height: '325px' }}>
               <WeeklyEarthquakeChart />

--- a/app/components/StatsSection/WeeklyStatsSection.tsx
+++ b/app/components/StatsSection/WeeklyStatsSection.tsx
@@ -1,0 +1,78 @@
+import { useAtomValue } from 'jotai';
+import {
+  currentWeekRangeStringAtom,
+  allWeeklyEventsAtom,
+  weeklyTopEventsAtom,
+  weeklyActiveLocationsAtom,
+} from '@/store';
+import BreakdownCalendar from './BreakdownCalendar';
+import MostActiveLocations from './MostActiveLocations';
+import StandardQuakeCard from '../StandardQuakeCard';
+import TotalEarthquakes from './TotalEarthquakes';
+import WeeklyEarthquakeChart from '../Charts/WeeklyEarthquakeChart';
+
+const WeeklyStatsSection = () => {
+  const weekRange = useAtomValue(currentWeekRangeStringAtom);
+  const weeklyEvents = useAtomValue(allWeeklyEventsAtom);
+  const activeLocations = useAtomValue(weeklyActiveLocationsAtom);
+  const topEvents = useAtomValue(weeklyTopEventsAtom);
+  const totalCount = weeklyEvents?.length;
+
+  if (!weeklyEvents) return null; //TODO: return spinner
+
+  return (
+    <div className="flex flex-col gap-20 px-4 py-10 sm:px-10 md:px-10 lg:px-20 xl:px-40 2xl:px-80">
+      <div className="grid grid-cols-1 md:grid-cols-[2fr_2fr_1fr] lg:grid-cols-[2fr_2fr_1fr] gap-4">
+        {/* Calendar and Total area */}
+        <div className="flex flex-col gap-4 min-h-full">
+          <div
+            className="border-[0.75px] border-gray-100 
+            flex bg-white rounded-lg p-4
+             "
+          >
+            <p className="text-4xl font-bold text-blue-800">Today</p>
+          </div>
+          <BreakdownCalendar calendarDate={weekRange} calendarText="Week of" />
+          <TotalEarthquakes totalCount={totalCount} maxValue={600} />
+        </div>
+
+        {/** Events Graph and Most Active area */}
+        {/**TODO: make nivo graph responsive without hard-coded height */}
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm sm:w-[100%] md:w-[325px] lg:w-[400px] xl:w-[100%] border-[0.75px] border-gray-100">
+            <p className="text-lg font-semibold text-blue-800">
+              Events Throughout Day
+            </p>
+            <div style={{ width: '100%', height: '325px' }}>
+              <WeeklyEarthquakeChart />
+            </div>
+          </div>
+          <MostActiveLocations locations={activeLocations} />
+        </div>
+
+        {/** Top 3 of the Day */}
+        <div className="flex flex-col items-center p-4 bg-white rounded-lg shadow-sm border-[0.75px] border-gray-100">
+          <h2 className="text-lg font-semibold text-blue-800">
+            Notable Events
+          </h2>
+          <div className="flex flex-col justify-center flex-wrap gap-6 ">
+            {topEvents &&
+              topEvents.map((event) => {
+                return (
+                  <StandardQuakeCard
+                    key={event.properties?.code}
+                    place={event.properties?.place}
+                    mag={event.properties?.mag}
+                    time={event.properties?.time}
+                    url={event.properties?.url}
+                  />
+                );
+              })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WeeklyStatsSection;

--- a/app/components/StatsSection/index.ts
+++ b/app/components/StatsSection/index.ts
@@ -1,1 +1,2 @@
-export { default as StatsSection } from './StatsSection';
+export { default as DailyStatsSection } from './DailyStatsSection';
+export { default as WeeklyStatsSection } from './WeeklyStatsSection';

--- a/app/components/ToolPanel/ToolPanel.tsx
+++ b/app/components/ToolPanel/ToolPanel.tsx
@@ -7,7 +7,6 @@ import { FaChevronDown } from 'react-icons/fa';
 import { FaChevronUp } from 'react-icons/fa';
 import { FaScrewdriverWrench } from 'react-icons/fa6';
 
-//TODO: Create an overlay button view for this to open and close the selected quakes pane
 const ToolPanel = () => {
   const earthquakes = useAtomValue(selectedEarthquakesAtom);
   const [toolPanelOpen, setToolPanelOpen] = useAtom(toolPanelOpenAtom);

--- a/app/facts/page.tsx
+++ b/app/facts/page.tsx
@@ -5,30 +5,16 @@ export default async function FactsPage() {
   const dailyEventsData = await fetchDailyStats();
   const weeklyEventsData = await fetchWeeklyStats();
 
-  const {
-    dailyEvents,
-    dailyEventsTotal,
-    dailyEventsWithTimes,
-    topMagnitudeDailyEvents,
-  } = dailyEventsData;
-
-  const {
-    //weeklyEvents,
-    weeklyEventsTotal,
-    topMagnitudeWeeklyEvents,
-    //eventsByWeekday,
-  } = weeklyEventsData;
+  const { dailyEvents, dailyEventsWithTimes } = dailyEventsData;
+  const { weeklyEvents, eventsByDate } = weeklyEventsData;
 
   return (
     <div className="relative">
       <FactsPageContent
         allDailyEvents={dailyEvents}
         dailyEventsWithTimes={dailyEventsWithTimes}
-        topMagnitudeEvents={topMagnitudeDailyEvents}
-        totalCount={dailyEventsTotal}
-        // weedkly
-        weeklyTopMagnitudeEvents={topMagnitudeWeeklyEvents}
-        weeklyTotalCount={weeklyEventsTotal}
+        allWeeklyEvents={weeklyEvents}
+        eventsByDate={eventsByDate}
       />
     </div>
   );

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,9 +1,9 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai';
 import { Feature, Point } from 'geojson';
 import { MapRef } from 'react-map-gl';
-import { EarthquakeEvent } from '@/utils/fetchEarthquakes';
+import { EventTimeAndMagnitude } from '@/utils/fetchEarthquakes';
 import { Earthquakes } from '@/types';
-import { EarthquakeFeature } from '@/types';
+import { EarthquakeFeature, EventsDateAndCount } from '@/types';
 import {
   getStartOfRange,
   processEarthquakeDataByHour,
@@ -45,9 +45,9 @@ export const currentWeekRangeStringAtom = atom((get) => {
 });
 
 /* ------------------------------- DAILY ATOMS ------------------------------ */
-export const dailyEventsWithTimesAtom = atom<EarthquakeEvent[] | undefined>(
-  undefined
-);
+export const dailyEventsWithTimesAtom = atom<
+  EventTimeAndMagnitude[] | undefined
+>(undefined);
 
 export const allDailyEventsAtom = atom<Earthquakes | undefined>(undefined);
 
@@ -105,9 +105,7 @@ export const weeklyActiveLocationsAtom = atom((get) => {
   return getMostActiveLocations(weeklyEvents);
 });
 
-type EventsByWeekday = {
-  [key: string]: number;
-};
-
-export const eventsByWeekdayAtom = atom<EventsByWeekday | undefined>(undefined);
+export const EventsDateAndCountAtom = atom<EventsDateAndCount | undefined>(
+  undefined
+);
 /* ---------------------------- END WEEKLY ATOMS ---------------------------- */

--- a/store/index.ts
+++ b/store/index.ts
@@ -3,6 +3,14 @@ import { Feature, Point } from 'geojson';
 import { MapRef } from 'react-map-gl';
 import { EarthquakeEvent } from '@/utils/fetchEarthquakes';
 import { Earthquakes } from '@/types';
+import { EarthquakeFeature } from '@/types';
+import {
+  getStartOfRange,
+  processEarthquakeDataByHour,
+  getMostActiveLocations,
+} from './utils';
+
+//TODO: Move helpers to an atoms utils module
 
 export const toolPanelOpenAtom = atom<Boolean>(true);
 
@@ -28,14 +36,6 @@ export const currentDateStringAtom = atom((get) =>
   get(currentDateAtom).toDateString()
 );
 
-// helper to calculate the start of the week to today
-const getStartOfRange = (date: Date) => {
-  const currentDate = new Date(date);
-  const startOfRange = new Date(currentDate);
-  startOfRange.setDate(currentDate.getDate() - 7);
-  return startOfRange;
-};
-
 // current week's range (ending with today's date)
 export const currentWeekRangeStringAtom = atom((get) => {
   const currentDate = get(currentDateAtom);
@@ -44,7 +44,7 @@ export const currentWeekRangeStringAtom = atom((get) => {
   return `${startOfRange.toDateString()} - ${currentDate.toDateString()}`;
 });
 
-// NEW ATOMS
+/* ------------------------------- DAILY ATOMS ------------------------------ */
 export const dailyEventsWithTimesAtom = atom<EarthquakeEvent[] | undefined>(
   undefined
 );
@@ -58,22 +58,22 @@ export const processedDailyEventsWithTimesAtom = atom<
 
   if (!dailyEvents) return undefined;
 
-  return processEarthquakeData(dailyEvents);
+  return processEarthquakeDataByHour(dailyEvents);
 });
 
-const processEarthquakeData = (
-  events: EarthquakeEvent[]
-): { hour: number; count: number }[] => {
-  const hourlyCounts = Array(24).fill(0);
+export const dailyTopEventsAtom = atom((get) => {
+  const dailyEvents = get(allDailyEventsAtom);
 
-  events.forEach((event) => {
-    const date = new Date(event.time);
-    const hour = date.getUTCHours(); // using UTC hour - we can handle converting later
-    hourlyCounts[hour]++;
-  });
+  if (!dailyEvents) return undefined;
 
-  return hourlyCounts.map((count, hour) => ({ hour, count }));
-};
+  // get the top 3 magnitude events
+  return dailyEvents
+    .sort(
+      (a: EarthquakeFeature, b: EarthquakeFeature) =>
+        b.properties?.mag - a.properties?.mag
+    )
+    .slice(0, 3);
+});
 
 export const dailyActiveLocationsAtom = atom((get) => {
   const dailyEvents = get(allDailyEventsAtom);
@@ -81,21 +81,33 @@ export const dailyActiveLocationsAtom = atom((get) => {
   return getMostActiveLocations(dailyEvents);
 });
 
-// most active locations
-// I don't have a table of country geometries to compare features to... but maybe I could create one?
-const getMostActiveLocations = (earthquakes: Earthquakes) => {
-  const regions: { [key: string]: number } = {};
+/* ----------------------------- END DAILY ATOMS ---------------------------- */
 
-  earthquakes.forEach((event) => {
-    const region = event.properties?.place.split(', ').pop();
+/* ------------------------------ WEEKLY ATOMS ------------------------------ */
+export const allWeeklyEventsAtom = atom<Earthquakes | undefined>(undefined);
 
-    if (regions[region]) {
-      regions[region]++;
-    } else {
-      regions[region] = 1;
-    }
-  });
+export const weeklyTopEventsAtom = atom((get) => {
+  const weeklyEvents = get(allWeeklyEventsAtom);
 
-  const sortedRegions = Object.entries(regions).sort((a, b) => b[1] - a[1]);
-  return sortedRegions.slice(0, 3).map((region) => region[0]);
+  if (!weeklyEvents) return undefined;
+
+  return weeklyEvents
+    .sort(
+      (a: EarthquakeFeature, b: EarthquakeFeature) =>
+        b.properties?.mag - a.properties?.mag
+    )
+    .slice(0, 3);
+});
+
+export const weeklyActiveLocationsAtom = atom((get) => {
+  const weeklyEvents = get(allWeeklyEventsAtom);
+  if (!weeklyEvents) return undefined;
+  return getMostActiveLocations(weeklyEvents);
+});
+
+type EventsByWeekday = {
+  [key: string]: number;
 };
+
+export const eventsByWeekdayAtom = atom<EventsByWeekday | undefined>(undefined);
+/* ---------------------------- END WEEKLY ATOMS ---------------------------- */

--- a/store/utils/index.ts
+++ b/store/utils/index.ts
@@ -1,0 +1,47 @@
+import { EarthquakeEvent } from '@/utils/fetchEarthquakes';
+import { Earthquakes } from '@/types';
+// helper to calculate the start of the week to today
+export const getStartOfRange = (date: Date) => {
+  const currentDate = new Date(date);
+  const startOfRange = new Date(currentDate);
+  startOfRange.setDate(currentDate.getDate() - 7);
+  return startOfRange;
+};
+
+// we're processing this data twice, once on the request, and once here - seems a little confusing
+/** Helper to organize events by time of day - DAILY */
+export const processEarthquakeDataByHour = (
+  events: EarthquakeEvent[]
+): { hour: number; count: number }[] => {
+  const hourlyCounts = Array(24).fill(0);
+
+  events.forEach((event) => {
+    const date = new Date(event.time);
+    const hour = date.getUTCHours(); // using UTC hour - we can handle converting later
+    hourlyCounts[hour]++;
+  });
+
+  return hourlyCounts.map((count, hour) => ({ hour, count }));
+};
+
+// I don't have a table of country geometries to compare features to... but maybe I could create one?
+export const getMostActiveLocations = (earthquakes: Earthquakes) => {
+  const regions: { [key: string]: number } = {};
+
+  // not the most reliable search, but there's no control over the API here
+  // count and group events by their `place` prop
+  earthquakes.forEach((event) => {
+    const region = event.properties?.place.split(', ').pop();
+
+    if (regions[region]) {
+      regions[region]++;
+    } else {
+      regions[region] = 1;
+    }
+  });
+
+  // sort the region by times they appeared
+  const sortedRegions = Object.entries(regions).sort((a, b) => b[1] - a[1]);
+  // return the most seen place
+  return sortedRegions.slice(0, 3).map((region) => region[0]);
+};

--- a/store/utils/index.ts
+++ b/store/utils/index.ts
@@ -1,4 +1,4 @@
-import { EarthquakeEvent } from '@/utils/fetchEarthquakes';
+import { EventTimeAndMagnitude } from '@/utils/fetchEarthquakes';
 import { Earthquakes } from '@/types';
 // helper to calculate the start of the week to today
 export const getStartOfRange = (date: Date) => {
@@ -11,7 +11,7 @@ export const getStartOfRange = (date: Date) => {
 // we're processing this data twice, once on the request, and once here - seems a little confusing
 /** Helper to organize events by time of day - DAILY */
 export const processEarthquakeDataByHour = (
-  events: EarthquakeEvent[]
+  events: EventTimeAndMagnitude[]
 ): { hour: number; count: number }[] => {
   const hourlyCounts = Array(24).fill(0);
 

--- a/types.ts
+++ b/types.ts
@@ -3,3 +3,7 @@ import { Feature, Point } from 'geojson';
 export type EarthquakeFeature = Feature<Point>;
 
 export type Earthquakes = EarthquakeFeature[];
+
+export type EventsDateAndCount = {
+  [key: string]: number;
+};

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 import { Earthquakes, EarthquakeFeature } from '@/types';
 
 //TODO: Why are we using axios? I could probably swap this for fetch and get some benefits from next
-//TODO: Cleanup - lots of functions here doing super similar things - we can streamline them, and integrate them with atoms where appropriate
 
 /** Fetch all the earthquake event geojson from today so far - all magnitudes */
 export const fetchEarthquakes = async (): Promise<Earthquakes> => {

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -14,7 +14,7 @@ export const fetchEarthquakes = async (): Promise<Earthquakes> => {
 };
 
 /** Fetch today's significant events with timestamps */
-export interface EarthquakeEvent {
+export interface EventTimeAndMagnitude {
   time: number; // Timestamp of the earthquake
   magnitude: number;
 }


### PR DESCRIPTION
- Breakout Daily and Weekly stats into their own component - this was better than ONE StateSection component where we retrieved a bunch of atoms and used ternaries to decide which values to use 
- Adds `WeeklyEarthquakeChart` (bar chart)
- Organize the `fetchDailyStats` function - removing some transforms I didn't need or see a place for in the API request, moving that logic to atoms where appropriate 
- Update `fetchWeeklyStats` - I was organizing by day of the week based on the UTC timestamp, using a scale of 0-6 for Sun-Sat. But I realized this was leading to misinterpretation of the data - and the WeeklyEarthquakeChart was seemingly predicting the future 🔮
- Organized the atom store and added a utils module 

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/c64a4c68-d058-4cbe-b699-a7e25f0239af">