### PR TITLE
chore: simplify parent containers in the stats components

### DIFF
--- a/app/components/StatsSection/DailyStatsSection.tsx
+++ b/app/components/StatsSection/DailyStatsSection.tsx
@@ -28,8 +28,8 @@ const DailyStatsSection = () => {
   if (!dailyEvents) return null; //TODO: return spinner
 
   return (
-    <div className="flex flex-col gap-20 px-4 py-10 sm:px-10 md:px-10 lg:px-20 xl:px-40 2xl:px-[500px]">
-      <div className="grid grid-cols-1 md:grid-cols-[2fr_2fr_1fr] lg:grid-cols-[2fr_2fr_1fr] gap-4">
+    <div className="p-8">
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_min-content] gap-6">
         {/* Calendar and Total area */}
         <div className="flex flex-col gap-4 min-h-full">
           <div

--- a/app/components/StatsSection/WeeklyStatsSection.tsx
+++ b/app/components/StatsSection/WeeklyStatsSection.tsx
@@ -21,8 +21,8 @@ const WeeklyStatsSection = () => {
   if (!weeklyEvents) return null; //TODO: return spinner
 
   return (
-    <div className="flex flex-col gap-20 px-4 py-10 sm:px-10 md:px-10 lg:px-20 xl:px-40 2xl:px-[500px]">
-      <div className="grid grid-cols-1 md:grid-cols-[2fr_2fr_1fr] lg:grid-cols-[2fr_2fr_1fr] gap-4">
+    <div className="p-8">
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_1fr_min-content] gap-6">
         {/* Calendar and Total area */}
         <div className="flex flex-col gap-4 min-h-full">
           <div


### PR DESCRIPTION
The 'stats' components for weekly/daily stats had a lot going on with styles defined in the `className` that weren't really helping us. 

Work removes a lot of the flex settings, and simplifies `grid` setting in the components.

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/0a278819-2488-40a3-8a07-1c451fc0d809">

Nothing looks radically different, but it sizes with the screen better, and seems to shift around less.  
