### PR TITLE
feat: add weekly daily map layers

### DIFF
--- a/app/components/Charts/DailyEarthquakeChart.tsx
+++ b/app/components/Charts/DailyEarthquakeChart.tsx
@@ -30,7 +30,7 @@ const DailyEarthquakeChart: React.FC = () => {
   }));
 
   return (
-    <div style={{ width: '100%', height: '100%' }}>
+    <div style={{ width: '100%', height: '100%', minWidth: '325px' }}>
       <ResponsiveBar
         data={chartData}
         keys={['count']}

--- a/app/components/Charts/WeeklyEarthquakeChart.tsx
+++ b/app/components/Charts/WeeklyEarthquakeChart.tsx
@@ -33,7 +33,7 @@ const WeeklyEarthquakeChart: React.FC = () => {
     .reverse(); // reverse to lead UP to today, as the week range displays
 
   return (
-    <div style={{ width: '100%', height: '100%' }}>
+    <div style={{ width: '100%', height: '100%', minWidth: '325px' }}>
       <ResponsiveBar
         data={chartData}
         // keys determines the height of each bar

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1,13 +1,22 @@
 'use client';
 import React, { useCallback, useState, useRef } from 'react';
 import { useAtom, useSetAtom } from 'jotai';
-import { selectedEarthquakesAtom, mapRefAtom } from '@/store';
-import ReactMapGL, { Source, Layer, Popup, MapRef } from 'react-map-gl';
+import useSyncAtom from '@/store/useSyncAtom';
+import {
+  selectedEarthquakesAtom,
+  mapRefAtom,
+  allDailyEventsAtom,
+  allWeeklyEventsAtom,
+} from '@/store';
+import ReactMapGL, { Popup, MapRef } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
-import { Feature, FeatureCollection, Point } from 'geojson';
+import { Feature, Point } from 'geojson';
+import DailyLayer from './layers/DailyEarthquakesLayer';
+import WeeklyLayer from './layers/WeeklyEarthquakesLayer';
 
 type MapProps = {
   earthquakes: Feature<Point>[];
+  weeklyEarthquakes: Feature<Point>[];
 };
 
 type PopupInfo = {
@@ -23,7 +32,13 @@ type PopupInfo = {
 };
 // TODO: breakout the layers
 // TODO: Add a layer for the weeks high magnitude events
-const Map = ({ earthquakes }: MapProps) => {
+const Map = ({ earthquakes, weeklyEarthquakes }: MapProps) => {
+  // set the atoms that will feed the geojson to map layers
+  // daily is ALL events today
+  useSyncAtom(allDailyEventsAtom, earthquakes);
+  // weekly is events over 2.5 magnitude
+  useSyncAtom(allWeeklyEventsAtom, weeklyEarthquakes);
+
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapRef | null>(null);
   const setMapRef = useSetAtom(mapRefAtom);
@@ -37,13 +52,8 @@ const Map = ({ earthquakes }: MapProps) => {
   const [selectedEarthquakes, setSelectedEarthquakes] = useAtom(
     selectedEarthquakesAtom
   );
-  const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
 
-  // we can just return this ssr?
-  const earthquakeGeoJSON: FeatureCollection<Point> = {
-    type: 'FeatureCollection',
-    features: earthquakes,
-  };
+  const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
 
   const onHover = (event: any) => {
     const {
@@ -101,7 +111,7 @@ const Map = ({ earthquakes }: MapProps) => {
         style={{ width: '100%', height: '100%' }}
         mapStyle="mapbox://styles/mapbox/navigation-day-v1"
         mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
-        interactiveLayerIds={['earthquake-layer']}
+        interactiveLayerIds={['earthquake-layer', 'weekly-earthquake-layer']}
         interactive={true}
         onMouseMove={onHover}
         onClick={onClick}
@@ -110,43 +120,8 @@ const Map = ({ earthquakes }: MapProps) => {
         onLoad={onMapLoad}
         ref={mapRef}
       >
-        {earthquakes.length > 0 && (
-          <Source id="earthquake-layer" type="geojson" data={earthquakeGeoJSON}>
-            <Layer
-              id="earthquake-layer"
-              type="circle"
-              paint={{
-                'circle-radius': [
-                  'interpolate',
-                  ['linear'],
-                  ['get', 'mag'],
-                  6,
-                  12,
-                  18,
-                  24,
-                ],
-                'circle-color': [
-                  'interpolate',
-                  ['linear'],
-                  ['get', 'mag'],
-                  1,
-                  '#2DC4B2',
-                  2,
-                  '#3BB3C3',
-                  3,
-                  '#669EC4',
-                  4,
-                  '#8B88B6',
-                  5,
-                  '#A2719B',
-                  6,
-                  '#AA5E79',
-                ],
-                'circle-opacity': 0.8,
-              }}
-            />
-          </Source>
-        )}
+        <DailyLayer />
+        <WeeklyLayer />
         {popupInfo && (
           <Popup
             longitude={popupInfo.longitude}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -30,7 +30,7 @@ type PopupInfo = {
   x: number;
   y: number;
 };
-// TODO: breakout the layers
+
 // TODO: Add a layer for the weeks high magnitude events
 const Map = ({ earthquakes, weeklyEarthquakes }: MapProps) => {
   // set the atoms that will feed the geojson to map layers
@@ -38,22 +38,13 @@ const Map = ({ earthquakes, weeklyEarthquakes }: MapProps) => {
   useSyncAtom(allDailyEventsAtom, earthquakes);
   // weekly is events over 2.5 magnitude
   useSyncAtom(allWeeklyEventsAtom, weeklyEarthquakes);
-
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapRef | null>(null);
   const setMapRef = useSetAtom(mapRefAtom);
-
-  const onMapLoad = useCallback(() => {
-    if (mapRef.current) {
-      setMapRef(mapRef.current);
-    }
-  }, [setMapRef]);
-
+  const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
   const [selectedEarthquakes, setSelectedEarthquakes] = useAtom(
     selectedEarthquakesAtom
   );
-
-  const [popupInfo, setPopupInfo] = useState<PopupInfo | null>(null);
 
   const onHover = (event: any) => {
     const {
@@ -76,6 +67,12 @@ const Map = ({ earthquakes, weeklyEarthquakes }: MapProps) => {
   const clearPopup = () => {
     setPopupInfo(null);
   };
+
+  const onMapLoad = useCallback(() => {
+    if (mapRef.current) {
+      setMapRef(mapRef.current);
+    }
+  }, [setMapRef]);
 
   const onClick = (event: any) => {
     const { features } = event;

--- a/app/components/ToolPanel/ToolPanel.tsx
+++ b/app/components/ToolPanel/ToolPanel.tsx
@@ -1,6 +1,10 @@
 'use client';
 import { useAtom, useAtomValue } from 'jotai';
-import { selectedEarthquakesAtom, toolPanelOpenAtom } from '@/store';
+import {
+  activeLayersAtom,
+  selectedEarthquakesAtom,
+  toolPanelOpenAtom,
+} from '@/store';
 import EarthquakeActions from './EarthquakeActions';
 import QuakeCards from '../QuakeCard';
 import { FaChevronDown } from 'react-icons/fa';
@@ -10,7 +14,11 @@ import { FaScrewdriverWrench } from 'react-icons/fa6';
 const ToolPanel = () => {
   const earthquakes = useAtomValue(selectedEarthquakesAtom);
   const [toolPanelOpen, setToolPanelOpen] = useAtom(toolPanelOpenAtom);
+  const [activeLayers, setActiveLayer] = useAtom(activeLayersAtom);
+  console.log('Active Layers: ', activeLayers);
 
+  // TODO: would probably look better if we migrated this to an AppShell component
+  // it can slide in and take a set amount of the left side of the screen
   return (
     <div
       className={`absolute top-[20px] right-[20px] bg-gray-100 shadow-inner border-[2px] border-gray-200 z-1000 p-4 rounded-lg overflow-hidden min-w-[280px] max-w-[280px] text-blue-800 transition-all duration-300 ${
@@ -28,7 +36,31 @@ const ToolPanel = () => {
       </div>
       {/** this will be the mass action toolbar - it should only show when earthquakes are selected */}
       {/* {earthquakes && <EarthquakeActions />} */}
-
+      <div>
+        <h2>Layers</h2>
+        <button
+          onClick={() => {
+            setActiveLayer({
+              daily: !activeLayers.daily,
+              weekly: activeLayers.weekly,
+            });
+          }}
+          className="p-2 bg-blue-100"
+        >
+          Daily
+        </button>
+        <button
+          onClick={() => {
+            setActiveLayer({
+              daily: activeLayers.daily,
+              weekly: !activeLayers.weekly,
+            });
+          }}
+          className="p-2 bg-blue-100"
+        >
+          Weekly
+        </button>
+      </div>
       {earthquakes && <QuakeCards />}
       {!earthquakes.length && (
         <p className="text-blue-800 text-md px-2 py-1 bg-white rounded-md shadow-lg border-[0.75px] border-gray-100">

--- a/app/components/ToolPanel/ToolPanel.tsx
+++ b/app/components/ToolPanel/ToolPanel.tsx
@@ -10,12 +10,13 @@ import QuakeCards from '../QuakeCard';
 import { FaChevronDown } from 'react-icons/fa';
 import { FaChevronUp } from 'react-icons/fa';
 import { FaScrewdriverWrench } from 'react-icons/fa6';
+import { FaEye } from 'react-icons/fa';
+import { FaEyeSlash } from 'react-icons/fa';
 
 const ToolPanel = () => {
   const earthquakes = useAtomValue(selectedEarthquakesAtom);
   const [toolPanelOpen, setToolPanelOpen] = useAtom(toolPanelOpenAtom);
   const [activeLayers, setActiveLayer] = useAtom(activeLayersAtom);
-  console.log('Active Layers: ', activeLayers);
 
   // TODO: would probably look better if we migrated this to an AppShell component
   // it can slide in and take a set amount of the left side of the screen
@@ -37,29 +38,37 @@ const ToolPanel = () => {
       {/** this will be the mass action toolbar - it should only show when earthquakes are selected */}
       {/* {earthquakes && <EarthquakeActions />} */}
       <div>
-        <h2>Layers</h2>
-        <button
-          onClick={() => {
-            setActiveLayer({
-              daily: !activeLayers.daily,
-              weekly: activeLayers.weekly,
-            });
-          }}
-          className="p-2 bg-blue-100"
-        >
-          Daily
-        </button>
-        <button
-          onClick={() => {
-            setActiveLayer({
-              daily: activeLayers.daily,
-              weekly: !activeLayers.weekly,
-            });
-          }}
-          className="p-2 bg-blue-100"
-        >
-          Weekly
-        </button>
+        <h2 className="font-semibold text-lg">Layers</h2>
+        <div className="flex gap-4 py-2">
+          <button
+            onClick={() => {
+              setActiveLayer({
+                daily: !activeLayers.daily,
+                weekly: activeLayers.weekly,
+              });
+            }}
+            className={`flex items-center gap-2 p-2 ${
+              activeLayers.daily ? 'bg-white' : 'bg-gray-200'
+            } rounded-md`}
+          >
+            Daily
+            {activeLayers.daily ? <FaEye /> : <FaEyeSlash />}
+          </button>
+          <button
+            onClick={() => {
+              setActiveLayer({
+                daily: activeLayers.daily,
+                weekly: !activeLayers.weekly,
+              });
+            }}
+            className={`flex items-center gap-2 p-2 ${
+              activeLayers.weekly ? 'bg-white' : 'bg-gray-200'
+            } rounded-md`}
+          >
+            Weekly
+            {activeLayers.weekly ? <FaEye /> : <FaEyeSlash />}
+          </button>
+        </div>
       </div>
       {earthquakes && <QuakeCards />}
       {!earthquakes.length && (

--- a/app/components/ToolPanel/ToolPanel.tsx
+++ b/app/components/ToolPanel/ToolPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useAtom, useAtomValue } from 'jotai';
+import Link from 'next/link';
 import {
   activeLayersAtom,
   selectedEarthquakesAtom,
@@ -69,6 +70,13 @@ const ToolPanel = () => {
             {activeLayers.weekly ? <FaEye /> : <FaEyeSlash />}
           </button>
         </div>
+        {activeLayers.weekly && (
+          <div className="py-2">
+            <p className="text-sm">
+              Weekly events are those of 2.5 or greater magnitude
+            </p>
+          </div>
+        )}
       </div>
       {earthquakes && <QuakeCards />}
       {!earthquakes.length && (

--- a/app/components/layers/DailyEarthquakesLayer.tsx
+++ b/app/components/layers/DailyEarthquakesLayer.tsx
@@ -1,0 +1,56 @@
+'use client';
+import React from 'react';
+import { useAtomValue } from 'jotai';
+import { dailyLayerGeoJSONAtom, activeLayersAtom } from '@/store';
+import { Source, Layer } from 'react-map-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+const DailyLayer = () => {
+  //get the value of earthquake geo json atom
+  const earthquakeGeoJSON = useAtomValue(dailyLayerGeoJSONAtom);
+  const activeLayers = useAtomValue(activeLayersAtom);
+  // get value of layer config - build some type of "selected layers" atom to track what's turned on and off
+  // if daily layer not selected, return null
+
+  if (!activeLayers.daily) return null;
+
+  return (
+    <Source id="earthquake-layer" type="geojson" data={earthquakeGeoJSON}>
+      <Layer
+        id="earthquake-layer"
+        type="circle"
+        paint={{
+          'circle-radius': [
+            'interpolate',
+            ['linear'],
+            ['get', 'mag'],
+            6,
+            12,
+            18,
+            24,
+          ],
+          'circle-color': [
+            'interpolate',
+            ['linear'],
+            ['get', 'mag'],
+            1,
+            '#2DC4B2',
+            2,
+            '#3BB3C3',
+            3,
+            '#669EC4',
+            4,
+            '#8B88B6',
+            5,
+            '#A2719B',
+            6,
+            '#AA5E79',
+          ],
+          'circle-opacity': 0.8,
+        }}
+      />
+    </Source>
+  );
+};
+
+export default DailyLayer;

--- a/app/components/layers/DailyEarthquakesLayer.tsx
+++ b/app/components/layers/DailyEarthquakesLayer.tsx
@@ -6,11 +6,8 @@ import { Source, Layer } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 const DailyLayer = () => {
-  //get the value of earthquake geo json atom
   const earthquakeGeoJSON = useAtomValue(dailyLayerGeoJSONAtom);
   const activeLayers = useAtomValue(activeLayersAtom);
-  // get value of layer config - build some type of "selected layers" atom to track what's turned on and off
-  // if daily layer not selected, return null
 
   if (!activeLayers.daily) return null;
 

--- a/app/components/layers/WeeklyEarthquakesLayer.tsx
+++ b/app/components/layers/WeeklyEarthquakesLayer.tsx
@@ -6,11 +6,9 @@ import { Source, Layer } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
 const WeeklyLayer = () => {
-  //get the value of earthquake geo json atom
   const earthquakeGeoJSON = useAtomValue(weeklyLayerGeoJSONAtom);
   const activeLayers = useAtomValue(activeLayersAtom);
-  // get value of layer config - build some type of "selected layers" atom to track what's turned on and off
-  // if weekly layer not selected, return null
+
   if (!activeLayers.weekly) return null;
   return (
     <Source

--- a/app/components/layers/WeeklyEarthquakesLayer.tsx
+++ b/app/components/layers/WeeklyEarthquakesLayer.tsx
@@ -1,0 +1,58 @@
+'use client';
+import React from 'react';
+import { useAtomValue } from 'jotai';
+import { weeklyLayerGeoJSONAtom, activeLayersAtom } from '@/store';
+import { Source, Layer } from 'react-map-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
+
+const WeeklyLayer = () => {
+  //get the value of earthquake geo json atom
+  const earthquakeGeoJSON = useAtomValue(weeklyLayerGeoJSONAtom);
+  const activeLayers = useAtomValue(activeLayersAtom);
+  // get value of layer config - build some type of "selected layers" atom to track what's turned on and off
+  // if weekly layer not selected, return null
+  if (!activeLayers.weekly) return null;
+  return (
+    <Source
+      id="weekly-earthquake-layer"
+      type="geojson"
+      data={earthquakeGeoJSON}
+    >
+      <Layer
+        id="weekly-earthquake-layer"
+        type="circle"
+        paint={{
+          'circle-radius': [
+            'interpolate',
+            ['linear'],
+            ['get', 'mag'],
+            6,
+            12,
+            18,
+            24,
+          ],
+          'circle-color': [
+            'interpolate',
+            ['linear'],
+            ['get', 'mag'],
+            1,
+            '#2DC4B2',
+            2,
+            '#3BB3C3',
+            3,
+            '#669EC4',
+            4,
+            '#8B88B6',
+            5,
+            '#A2719B',
+            6,
+            '#AA5E79',
+          ],
+          'circle-opacity': 0.8,
+        }}
+      />
+    </Source>
+  );
+};
+
+export default WeeklyLayer;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,16 +1,20 @@
 import Map from './components/Map';
 import ToolPanel from './components/ToolPanel';
-import { fetchEarthquakes } from '@/utils/fetchEarthquakes';
+import {
+  fetchEarthquakes,
+  fetchWeeklyEarthquakes,
+} from '@/utils/fetchEarthquakes';
 
 //TODO: investigate the best way to handle caching and revalidating in this use-case 🤔
 export const revalidate = 900; // revalidate every 15 minutes
 
 export default async function Home() {
   const earthquakes = await fetchEarthquakes();
+  const weeklyEarthquakes = await fetchWeeklyEarthquakes();
 
   return (
     <div className="relative">
-      <Map earthquakes={earthquakes} />
+      <Map earthquakes={earthquakes} weeklyEarthquakes={weeklyEarthquakes} />
       <ToolPanel />
     </div>
   );

--- a/store/index.ts
+++ b/store/index.ts
@@ -25,6 +25,13 @@ export const mapRefAtom = atom<MapRef | null>(null);
 export const useMap = () => useAtomValue(mapRefAtom);
 export const setMap = () => useSetAtom(mapRefAtom);
 
+/** Map Layer Configuration */
+// I see this getting really out of hand if the number of layers were to scale...
+export const activeLayersAtom = atom<any>({
+  daily: true,
+  weekly: false,
+});
+
 // Sneaky helpers
 //TODO: investigate improving these/making more reliable - moment js? a better ts option?
 export const currentDateAtom = atom(new Date());

--- a/store/index.ts
+++ b/store/index.ts
@@ -81,6 +81,7 @@ export const dailyActiveLocationsAtom = atom((get) => {
   return getMostActiveLocations(dailyEvents);
 });
 
+// atom to return the geojson for the dailyEarthquakeLayer
 export const dailyLayerGeoJSONAtom = atom((get) => {
   const earthquakes = get(allDailyEventsAtom);
   if (!earthquakes) return undefined;
@@ -119,6 +120,7 @@ export const EventsDateAndCountAtom = atom<EventsDateAndCount | undefined>(
   undefined
 );
 
+// atom to return the geojson for the weeklyEarthquakeLayer
 export const weeklyLayerGeoJSONAtom = atom((get) => {
   const earthquakes = get(allWeeklyEventsAtom);
   if (!earthquakes) return undefined;

--- a/store/index.ts
+++ b/store/index.ts
@@ -1,5 +1,5 @@
 import { atom, useAtomValue, useSetAtom } from 'jotai';
-import { Feature, Point } from 'geojson';
+import { Feature, Point, FeatureCollection } from 'geojson';
 import { MapRef } from 'react-map-gl';
 import { EventTimeAndMagnitude } from '@/utils/fetchEarthquakes';
 import { Earthquakes } from '@/types';
@@ -9,8 +9,6 @@ import {
   processEarthquakeDataByHour,
   getMostActiveLocations,
 } from './utils';
-
-//TODO: Move helpers to an atoms utils module
 
 export const toolPanelOpenAtom = atom<Boolean>(true);
 
@@ -28,7 +26,7 @@ export const useMap = () => useAtomValue(mapRefAtom);
 export const setMap = () => useSetAtom(mapRefAtom);
 
 // Sneaky helpers
-
+//TODO: investigate improving these/making more reliable - moment js? a better ts option?
 export const currentDateAtom = atom(new Date());
 
 // current week's range (ending with today's date)
@@ -76,6 +74,16 @@ export const dailyActiveLocationsAtom = atom((get) => {
   return getMostActiveLocations(dailyEvents);
 });
 
+export const dailyLayerGeoJSONAtom = atom((get) => {
+  const earthquakes = get(allDailyEventsAtom);
+  if (!earthquakes) return undefined;
+  const earthquakeGeoJSON: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: earthquakes,
+  };
+  return earthquakeGeoJSON;
+});
+
 /* ----------------------------- END DAILY ATOMS ---------------------------- */
 
 /* ------------------------------ WEEKLY ATOMS ------------------------------ */
@@ -103,4 +111,14 @@ export const weeklyActiveLocationsAtom = atom((get) => {
 export const EventsDateAndCountAtom = atom<EventsDateAndCount | undefined>(
   undefined
 );
+
+export const weeklyLayerGeoJSONAtom = atom((get) => {
+  const earthquakes = get(allWeeklyEventsAtom);
+  if (!earthquakes) return undefined;
+  const earthquakeGeoJSON: FeatureCollection<Point> = {
+    type: 'FeatureCollection',
+    features: earthquakes,
+  };
+  return earthquakeGeoJSON;
+});
 /* ---------------------------- END WEEKLY ATOMS ---------------------------- */

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -12,6 +12,14 @@ export const fetchEarthquakes = async (): Promise<Earthquakes> => {
   return res.data.features;
 };
 
+export const fetchWeeklyEarthquakes = async (): Promise<Earthquakes> => {
+  const res = await axios.get(
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_week.geojson'
+  );
+
+  return res.data.features;
+};
+
 /** Fetch today's significant events with timestamps */
 export interface EventTimeAndMagnitude {
   time: number; // Timestamp of the earthquake


### PR DESCRIPTION
- Adds `layers` directory in components, and adds a layer to render the weekly and daily earthquake events 
- Adds `activeLayersAtom` to keep track of what layers are turned on 
- Adds geoJSON atoms for the weekly and daily events, getting the events from the relevant daily and weeklyEventsAtom and returning it as a Feature Collection so it can be used by the map layers 
- Adds basic layer toggles in the ToolPanel
- Both layers can be turned on at the same time, and both layers get the hover popup and ability to click and store events in the tool panel sidebar 

<img width="1160" alt="image" src="https://github.com/user-attachments/assets/57db3ff1-c01e-4a8b-8f5c-884a5ca91a83">

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/545a21d3-d007-48c1-a8e8-a834920b7cf1">

