### PR TITLE
feat: DailyEarthquakesLayer magnitude level selections 

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -31,13 +31,13 @@ type PopupInfo = {
   y: number;
 };
 
-// TODO: Add a layer for the weeks high magnitude events
 const Map = ({ earthquakes, weeklyEarthquakes }: MapProps) => {
-  // set the atoms that will feed the geojson to map layers
+  // use the data fetched on the server on root page
   // daily is ALL events today
   useSyncAtom(allDailyEventsAtom, earthquakes);
   // weekly is events over 2.5 magnitude
   useSyncAtom(allWeeklyEventsAtom, weeklyEarthquakes);
+
   const mapContainerRef = useRef<HTMLDivElement | null>(null);
   const mapRef = useRef<MapRef | null>(null);
   const setMapRef = useSetAtom(mapRefAtom);

--- a/app/components/StatsSection/DailyStatsSection.tsx
+++ b/app/components/StatsSection/DailyStatsSection.tsx
@@ -16,7 +16,7 @@ const DailyStatsSection = () => {
   const dailyEvents = useAtomValue(allDailyEventsAtom);
   const topEvents = useAtomValue(dailyTopEventsAtom);
   const activeLocations = useAtomValue(dailyActiveLocationsAtom);
-  const totalCount = dailyEvents?.length;
+  const totalCount = topEvents?.length;
 
   const currentDate = atomDate.toLocaleDateString('en-US', {
     weekday: 'long',

--- a/app/components/ToolPanel/ToolPanel.tsx
+++ b/app/components/ToolPanel/ToolPanel.tsx
@@ -19,6 +19,40 @@ const ToolPanel = () => {
   const [toolPanelOpen, setToolPanelOpen] = useAtom(toolPanelOpenAtom);
   const [activeLayers, setActiveLayer] = useAtom(activeLayersAtom);
 
+  const toggleDailyLayer = () => {
+    if (
+      activeLayers.daily.high ||
+      activeLayers.daily.med ||
+      activeLayers.daily.low
+    ) {
+      setActiveLayer({
+        ...activeLayers,
+        daily: { high: false, med: false, low: false },
+      });
+    } else {
+      // just turn back on medium and high?
+      setActiveLayer({
+        ...activeLayers,
+        daily: { high: true, med: true, low: false },
+      });
+    }
+  };
+
+  const isDailyActive =
+    activeLayers.daily.low || activeLayers.daily.med || activeLayers.daily.high;
+
+  // helper to toggle magnitude levels with radio buttons
+  //TODO: refactor to be reusable for weekly
+  const toggleMagnitude = (level: 'low' | 'med' | 'high') => {
+    setActiveLayer({
+      ...activeLayers,
+      daily: {
+        ...activeLayers.daily,
+        [level]: !activeLayers.daily[level],
+      },
+    });
+  };
+
   // TODO: would probably look better if we migrated this to an AppShell component
   // it can slide in and take a set amount of the left side of the screen
   return (
@@ -40,21 +74,64 @@ const ToolPanel = () => {
       {/* {earthquakes && <EarthquakeActions />} */}
       <div>
         <h2 className="font-semibold text-lg">Layers</h2>
-        <div className="flex gap-4 py-2">
-          <button
-            onClick={() => {
-              setActiveLayer({
-                daily: !activeLayers.daily,
-                weekly: activeLayers.weekly,
-              });
-            }}
-            className={`flex items-center gap-2 p-2 ${
-              activeLayers.daily ? 'bg-white' : 'bg-gray-200'
-            } rounded-md`}
-          >
-            Daily
-            {activeLayers.daily ? <FaEye /> : <FaEyeSlash />}
-          </button>
+        <div className="py-2">
+          <div className="dailyContainer pb-2">
+            <button
+              onClick={toggleDailyLayer}
+              className={`flex items-center gap-2 p-2 ${
+                activeLayers.daily ? 'bg-white' : 'bg-gray-200'
+              } rounded-md`}
+            >
+              Daily
+              {isDailyActive ? <FaEye /> : <FaEyeSlash />}
+            </button>
+
+            {isDailyActive && (
+              <div className="flex gap-2 py-3">
+                <fieldset>
+                  <legend>Mag: </legend>
+                </fieldset>
+
+                <div>
+                  <input
+                    type="checkbox"
+                    id="high"
+                    name="high"
+                    value="high"
+                    checked={activeLayers.daily.high}
+                    onChange={() => toggleMagnitude('high')}
+                    style={{ marginRight: '4px' }}
+                  />
+                  <label htmlFor="high">High</label>
+                </div>
+                <div>
+                  <input
+                    type="checkbox"
+                    id="med"
+                    name="med"
+                    value="med"
+                    checked={activeLayers.daily.med}
+                    onChange={() => toggleMagnitude('med')}
+                    style={{ marginRight: '4px' }}
+                  />
+                  <label htmlFor="med">Medium</label>
+                </div>
+                <div>
+                  <input
+                    type="checkbox"
+                    id="low"
+                    name="low"
+                    value="low"
+                    checked={activeLayers.daily.low}
+                    onChange={() => toggleMagnitude('low')}
+                    style={{ marginRight: '4px' }}
+                  />
+                  <label htmlFor="low">Low</label>
+                </div>
+              </div>
+            )}
+          </div>
+
           <button
             onClick={() => {
               setActiveLayer({

--- a/app/components/layers/DailyEarthquakesLayer.tsx
+++ b/app/components/layers/DailyEarthquakesLayer.tsx
@@ -5,16 +5,14 @@ import { dailyLayerGeoJSONAtom, activeLayersAtom } from '@/store';
 import { Source, Layer } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
-// we'll break the daily and weekly layers into min, med, max
-// but should we have a route that now just gets ALL teh data at once on page.tsx?
-// or do we manage making the calls in atoms, and only fetch what's needed?
-
 const DailyLayer = () => {
   const earthquakeGeoJSON = useAtomValue(dailyLayerGeoJSONAtom);
   const activeLayers = useAtomValue(activeLayersAtom);
 
-  // TODO: If active layers for daily has no selection for low/med/high
-  if (!activeLayers.daily) return null;
+  const isDailyActive =
+    activeLayers.daily.low || activeLayers.daily.med || activeLayers.daily.high;
+
+  if (!isDailyActive) return null;
 
   return (
     <Source id="earthquake-layer" type="geojson" data={earthquakeGeoJSON}>

--- a/app/components/layers/DailyEarthquakesLayer.tsx
+++ b/app/components/layers/DailyEarthquakesLayer.tsx
@@ -5,10 +5,15 @@ import { dailyLayerGeoJSONAtom, activeLayersAtom } from '@/store';
 import { Source, Layer } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 
+// we'll break the daily and weekly layers into min, med, max
+// but should we have a route that now just gets ALL teh data at once on page.tsx?
+// or do we manage making the calls in atoms, and only fetch what's needed?
+
 const DailyLayer = () => {
   const earthquakeGeoJSON = useAtomValue(dailyLayerGeoJSONAtom);
   const activeLayers = useAtomValue(activeLayersAtom);
 
+  // TODO: If active layers for daily has no selection for low/med/high
   if (!activeLayers.daily) return null;
 
   return (

--- a/app/facts/page.tsx
+++ b/app/facts/page.tsx
@@ -1,10 +1,13 @@
-import { fetchDailyStats, fetchWeeklyStats } from '@/utils/fetchEarthquakes';
+import {
+  fetchDailyGraphStats,
+  fetchWeeklyStats,
+} from '@/utils/fetchEarthquakes';
 import FactsPageContent from '../components/FactsPageContent';
 
 export const revalidate = 900; // revalidate every 15 minutes
 
 export default async function FactsPage() {
-  const dailyEventsData = await fetchDailyStats();
+  const dailyEventsData = await fetchDailyGraphStats();
   const weeklyEventsData = await fetchWeeklyStats();
 
   const { dailyEvents, dailyEventsWithTimes } = dailyEventsData;

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -30,7 +30,7 @@ export interface EventTimeAndMagnitude {
 export const fetchDailyStats = async (): Promise<any> => {
   // fetch the earth quakes for the day
   const res = await axios.get(
-    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson'
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
   );
 
   const dailyEvents = res.data.features;
@@ -50,22 +50,20 @@ export const fetchDailyStats = async (): Promise<any> => {
 };
 
 export const fetchWeeklyStats = async (): Promise<any> => {
-  // fetch the earthquake day of significant magnitude for the week
   const res = await axios.get(
     'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_week.geojson'
   );
 
   const weeklyEvents = res.data.features;
 
-  // sort events by date
-  // ensure days are in correct order, ending with today
+  // sort events by date ensure days are in correct order, ending with today
   const eventsByDate = weeklyEvents.reduce(
     (acc: { [date: string]: number }, feature: EarthquakeFeature) => {
       const date = new Date(feature.properties?.time)
         .toISOString()
         .split('T')[0];
       if (!acc[date]) {
-        acc[date] = 0; // start at 0?
+        acc[date] = 0;
       }
       acc[date]++;
       return acc;

--- a/utils/fetchEarthquakes.ts
+++ b/utils/fetchEarthquakes.ts
@@ -26,11 +26,31 @@ export interface EventTimeAndMagnitude {
   magnitude: number;
 }
 
-// Attempt at single function to handle all day needs
 export const fetchDailyStats = async (): Promise<any> => {
-  // fetch the earth quakes for the day
   const res = await axios.get(
     'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/all_day.geojson'
+  );
+
+  const dailyEvents = res.data.features;
+
+  // sort by time and magnitude - for chart
+  const dailyEventsWithTimes = dailyEvents.map(
+    (feature: EarthquakeFeature) => ({
+      time: feature.properties?.time,
+      magnitude: feature.properties?.mag,
+    })
+  );
+
+  return {
+    dailyEvents,
+    dailyEventsWithTimes,
+  };
+};
+
+export const fetchDailyGraphStats = async (): Promise<any> => {
+  // fetch the earth quakes for the day 2.5 and above
+  const res = await axios.get(
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/2.5_day.geojson'
   );
 
   const dailyEvents = res.data.features;


### PR DESCRIPTION
## Changes 

- Breaks the `activeLayers` atom down - `daily` has become a nested object with three layers (high, med, low) 
- Updates the ToolPanel component, refactoring daily event toggling 
- Updates daily GeoJSON atom to flood map with data that matches criteria from the `activeLayers` selections 

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/63af60cb-096f-446f-87d0-2fa3c0d7e575">

## Testing 

1. `yarn dev` and visit the main page 
2. Make different selections for daily events 
3. Click daily button, all checkboxes should clear 
4. Map should update render depending on daily levels selected 
5. If all daily levels are false, magnitude selection should be removed from render (toggling daily button should bring it back)