### PR TITLE
feat: USGS API service class

### DIFF
--- a/utils/services/Earthquake.ts
+++ b/utils/services/Earthquake.ts
@@ -1,0 +1,12 @@
+export class EarthquakeService {
+  private baseURL: string =
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/';
+
+  /** Fetch all earthquakes for the day */
+
+  /** Fetch all earthquakes for the week */
+
+  /** Fetch earthquake stats (graph data) for the day */
+
+  /** Fetch earthquake stats (graph data) for the week */
+}

--- a/utils/services/Earthquake.ts
+++ b/utils/services/Earthquake.ts
@@ -1,12 +1,45 @@
+import { EarthquakeFeature } from '@/types';
+
 export class EarthquakeService {
   private baseURL: string =
-    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/';
+    'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary';
+
+  private async fetchData<T>(url: string): Promise<T> {
+    const res = await fetch(url);
+    if (!res.ok)
+      throw new Error(`Failed to fetch USGS data: ${res.statusText}`);
+    return await res.json();
+  }
 
   /** Fetch all earthquakes for the day */
+  public async fetchDailyEarthquakes(): Promise<EarthquakeFeature[]> {
+    const data = await this.fetchData<{ features: EarthquakeFeature[] }>(
+      `${this.baseURL}/all_day.geojson`
+    );
+    return data.features;
+  }
 
   /** Fetch all earthquakes for the week */
+  public async fetchWeeklyEarthquakes(): Promise<EarthquakeFeature[]> {
+    const data = await this.fetchData<{ features: EarthquakeFeature[] }>(
+      `${this.baseURL}/all_week.geojson`
+    );
+    return data.features;
+  }
 
   /** Fetch earthquake stats (graph data) for the day */
+  public async fetchDailyStats(): Promise<EarthquakeFeature[]> {
+    const data = await this.fetchData<{ features: EarthquakeFeature[] }>(
+      `${this.baseURL}/2.5_day.geojson`
+    );
+    return data.features;
+  }
 
   /** Fetch earthquake stats (graph data) for the week */
+  public async fetchWeeklyStats(): Promise<EarthquakeFeature[]> {
+    const data = await this.fetchData<{ features: EarthquakeFeature[] }>(
+      `${this.baseURL}/2.5_week.geojson`
+    );
+    return data.features;
+  }
 }


### PR DESCRIPTION
This is a simple addition - we're simply taking the base routes used in `fetchEarthquakes` and adding them to a service class named `EarthquakeService`. 

The goal of this was to simplify the way we're getting data into the app. This way we can manage a declarative class, and transition the logic (sorting, mapping, filtering) that we're doing into atoms. 

This work completes step one of that effort. 